### PR TITLE
Pin third-party actions to currently used SHA

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.17
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29


### PR DESCRIPTION
In light of the [recent compromise of the tj-actions/changed-files action](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised), we’re trying to reduce the risk incurred from our use of third-party actions. 

[GitHub documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends pinning third-party actions to a full length commit SHA as a good security practice, and as the only way to use an action as an immutable release.

This PR pins this repository’s third-party actions to their currently used version’s commit SHA, as indicated in the logs for the most recent workflow runs, or from the most recent matching release if logs are not available.

If desired, we can also look into adding a Dependabot configuration to help keep actions updated by automatically creating update PRs when new versions are available.